### PR TITLE
Don't convert strings with non-keyword characters in clj->js'

### DIFF
--- a/src/core/reagent_material_ui/util.cljs
+++ b/src/core/reagent_material_ui/util.cljs
@@ -26,6 +26,8 @@
   (and (string? s)
        (contains? #{\A \B \C \D \E \F \G \H \I \J \K \L \M \N \O \P \Q \R \S \T \U \V \W \X \Y \Z}
                   (first s))))
+(defn ^:private keyword-safe? [s]
+  (some? (re-matches #"[-*+!?<>='&$%#|\w]+" s)))
 
 (defn ^:private key->str [k]
   (let [n (name k)]
@@ -55,8 +57,10 @@
     (keyword? k) k
     (color-key? k) (keyword k)
     (numeric-string? k) (js/parseInt k)
-    (pascal-case? k) (keyword k)
-    :else (->kebab-case-keyword k)))
+    (keyword-safe? k) (if (pascal-case? k)
+                        (keyword k)
+                        (->kebab-case-keyword k))
+    :else k))
 
 (defn js->clj'
   [obj]

--- a/test/reagent_material_ui/util_test.cljs
+++ b/test/reagent_material_ui/util_test.cljs
@@ -59,4 +59,13 @@
         (is (= {:foo "foo"
                 :elems [elem]}
                result))
-        (is (identical? elem (first (:elems result))))))))
+        (is (identical? elem (first (:elems result))))))
+    (testing "doesn't convert strings with non-keyword characters"
+      (is (= {"@media (min-width: 600px)" 0
+              "div + span"                1
+              "div::before"               2
+              ".MuiButton-core"           3}
+             (js->clj' #js {"@media (min-width: 600px)" 0
+                            "div + span"                1
+                            "div::before"               2
+                            ".MuiButton-core"           3}))))))


### PR DESCRIPTION
Hello,

I noticed that that the `responsive-font-sizes` function in `reagent-material-ui.styles` doesn't appear to work; everything compiles without warning, but the styles don't change. This seems to be because the function creates JSS objects with keys like `"@media (min-width: 600px)"`, which get munged into keywords by `js->clj'` before being converted back to strings.

I added a simple check for non-keyword characters to your `js-key->clj` function, so that object properties with nonstandard names would be left alone. It's not perfect; colons, for instance, are treated as invalid, even though they're technically allowable in keywords at certain positions, but I figure it's better to be strict about what gets through, since `keyword` can have some pretty unpredictable behavior when it comes to edge cases. 

Anyway, thanks for your work on this library, it's really a pleasure to use. I hope this little fix is helpful, please let me know if I can do anything to improve it. 