### PR TITLE
Use default locale when opts contain null locale

### DIFF
--- a/src/core/reagent_material_ui/cljs_time_adapter.cljs
+++ b/src/core/reagent_material_ui/cljs_time_adapter.cljs
@@ -224,7 +224,7 @@
 (defn cljs-time-adapter
   "Adapter for using cljs-time with reagent-material-ui.lab.localization-provider"
   [opts]
-  (let [^DateTimeSymbols locale (obj/get opts "locale" DateTimeSymbols)
+  (let [^DateTimeSymbols locale (or (obj/get opts "locale") DateTimeSymbols)
         formats (or (js->clj (obj/get opts "formats")) default-formats)
         format (fn [date format-str]
                  (let [^DateTimeFormat formatter (DateTimeFormat. format-str locale)]


### PR DESCRIPTION
Hi, 

on my machine `date-time-picker` is crashing with the message `locale is undefined`. It looks like `localization-provider` function `date-adapter` is being called with opts `{ "locale": null, "formats": null, "instance": null }`. Since `cljs-time-adapter` is currently using `(obj/get opts "locale" DateTimeSymbols)` to resolve locale, null will be used. I have changed expression to `(or (obj/get opts "locale") DateTimeSymbols)` in order to use default locale when locale is null.