### PR TITLE
[cljs-time-adapter] use regular time instead of UTC as now

### DIFF
--- a/src/core/reagent_mui/cljs_time_adapter.cljs
+++ b/src/core/reagent_mui/cljs_time_adapter.cljs
@@ -36,7 +36,7 @@
 
 (defn ^:private to-cljs-date [value]
   (cond
-    (undefined? value) (time/now)
+    (undefined? value) (time/time-now)
     (nil? value) nil
     (time/date? value) value
     :else (coerce/to-date-time value)))


### PR DESCRIPTION
[`now` uses `UtcDatetime`](https://github.com/andrewmcveigh/cljs-time/blob/master/src/cljs_time/core.cljs#L289).

`npm run test`