### PR TITLE
Add startOfYear and endOfYear to cljs-time-adapter

### DIFF
--- a/src/core/reagent_mui/cljs_time_adapter.cljs
+++ b/src/core/reagent_mui/cljs_time_adapter.cljs
@@ -287,6 +287,10 @@
          :isWithinRange                (fn [date [from to]]
                                          (or (time/within? from to date)
                                              (time/equal? to date)))
+         :startOfYear                  (fn [date]
+                                         (start-of-year date))
+         :endOfYear                    (fn [date]
+                                         (end-of-year date))
          :startOfMonth                 (fn [date]
                                          (start-of-month date))
          :endOfMonth                   (fn [date]

--- a/test/reagent_mui/cljs_time_adapter_test.cljs
+++ b/test/reagent_mui/cljs_time_adapter_test.cljs
@@ -55,6 +55,14 @@
   (testing "endOfDay"
     (is (= "2018-10-30 23:59" (format-datetime (.endOfDay utils test-date))))))
 
+(deftest start-of-year-test
+  (testing "startOfYear"
+    (is (= "2018-01-01 00:00" (format-datetime (.startOfYear utils test-date))))))
+
+(deftest end-of-year-test
+  (testing "endOfYear"
+    (is (= "2018-12-31 23:59" (format-datetime (.endOfYear utils test-date))))))
+
 (deftest start-of-month-test
   (testing "startOfMonth"
     (is (= "2018-10-01 00:00" (format-datetime (.startOfMonth utils test-date))))))


### PR DESCRIPTION
CalendarPicker needs startOfYear and endOfYear methods in adapter.

Without those two methods, date picker with cljs-time-adapter as adapter will crash when user trying to pick different year. 
Issue can be reproduced in example.
<img width="779" alt="image" src="https://user-images.githubusercontent.com/30197887/199995860-f84abd75-135b-46a3-b673-1f631cd7354f.png">
